### PR TITLE
Remove filter headers unless in dev mode

### DIFF
--- a/code/solr/SolrIndex.php
+++ b/code/solr/SolrIndex.php
@@ -674,7 +674,7 @@ abstract class SolrIndex extends SearchIndex
             $params['qf'] = $qf;
         }
 
-        if (!headers_sent() && !Director::isLive()) {
+        if (!headers_sent() && Director::isDev()) {
             if ($q) {
                 header('X-Query: '.implode(' ', $q));
             }


### PR DESCRIPTION
Changing SolrIndex to only add the X-Query, X-Filters and X-QueryFields headers if in dev mode. This data is best kept private and should only be seen when in a dev environment. If in a test environment, these can be seen through the use of "?isDev=1".
